### PR TITLE
Removed extra clone operation inside Trajopt.

### DIFF
--- a/src/or_trajopt/__init__.py
+++ b/src/or_trajopt/__init__.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from .planning import TrajoptPlanner, TrajoptWrapper
+from .planning import (
+    TrajoptPlanner,
+    TrajoptWrapper,
+    ConstraintType,
+    CostType
+)
+
 assert TrajoptPlanner
 assert TrajoptWrapper
+assert ConstraintType
+assert CostType

--- a/src/or_trajopt/planning.py
+++ b/src/or_trajopt/planning.py
@@ -152,17 +152,17 @@ class TrajoptPlanner(BasePlanner):
         if isinstance(fntype, ConstraintType):
             if dfdx is not None:
                 problem.AddConstraint(f, dfdx, [(timestep, i) for i in inds],
-                                      fntype, fnname)
+                                      fntype.value, fnname)
             else:
                 problem.AddConstraint(f, [(timestep, i) for i in inds],
-                                      fntype, fnname)
+                                      fntype.value, fnname)
         elif isinstance(fntype, CostType):
             if dfdx is not None:
-                problem.AddConstraint(f, dfdx, [(timestep, i) for i in inds],
-                                      fntype, fnname)
+                problem.AddErrorCost(f, dfdx, [(timestep, i) for i in inds],
+                                     fntype.value, fnname)
             else:
-                problem.AddConstraint(f, [(timestep, i) for i in inds],
-                                      fntype, fnname)
+                problem.AddErrorCost(f, [(timestep, i) for i in inds],
+                                     fntype.value, fnname)
         else:
             ValueError('Invalid cost or constraint type: {:s}'
                        .format(str(fntype)))


### PR DESCRIPTION
Previously, due to bugs in the openrave environment cloning,
it was necessary to re-clone a fresh environment for TrajOpt on
each planning call to avoid stale OSG and Bullet references
corrupting the TrajOpt planner.

With new fixes, it is possible to simply exhaustively clear the
TrajOpt userdata on each planning call, removing this stale data
at much less cost than fully re-cloning the environment.
